### PR TITLE
Update oauth2-redirect.html

### DIFF
--- a/flask_swagger_ui/dist/oauth2-redirect.html
+++ b/flask_swagger_ui/dist/oauth2-redirect.html
@@ -35,7 +35,7 @@
             if (qp.code) {
                 delete oauth2.state;
                 oauth2.auth.code = qp.code;
-                oauth2.callback(oauth2.auth);
+                oauth2.callback(oauth2);
             } else {
                 oauth2.errCb({
                     authId: oauth2.auth.name,


### PR DESCRIPTION
oauth2 error fix for swag ui 3.1.*
```
oauth2-redirect.html?state=VHVlIEF1ZyAyOSAyMDE3IDA5OjA2OjQ5IEdNVCswODAwICgrMDgp&code=oFw2HyqT0xKHFg37Optt8xcJtadg43:43 Uncaught TypeError: Cannot read property 'schema' of undefined
    at t.authorizeAccessCodeWithFormParams (:5002/api/docs/v1/swagger-ui-bundle.js:9603)
    at :5002/api/docs/v1/swagger-ui-bundle.js:3777
    at Object.callback (:5002/api/docs/v1/swagger-ui-bundle.js:63541)
    at run (oauth2-redirect.html?state=VHVlIEF1ZyAyOSAyMDE3IDA5OjA2OjQ5IEdNVCswODAwICgrMDgp&code=oFw2HyqT0xKHFg37Optt8xcJtadg43:43)
    at onload (oauth2-redirect.html?state=VHVlIEF1ZyAyOSAyMDE3IDA5OjA2OjQ5IEdNVCswODAwICgrMDgp&code=oFw2HyqT0xKHFg37Optt8xcJtadg43:3)
t.authorizeAccessCodeWithFormParams	@	:5002/api/docs/v1/swagger-ui-bundle.js:9603
(anonymous)	@	:5002/api/docs/v1/swagger-ui-bundle.js:3777
(anonymous)	@	:5002/api/docs/v1/swagger-ui-bundle.js:63541
```